### PR TITLE
chore: Extract javascript script from workflows into their own files

### DIFF
--- a/.github/lib/comment-plan-output.js
+++ b/.github/lib/comment-plan-output.js
@@ -1,10 +1,9 @@
 
-module.exports = ({ context, github, stackName }) => {
+module.exports = ({ context, github, planOutcome, stackName }) => {
     const { readFileSync } = require("fs")
     const data = readFileSync(`./plan_stdout_${stackName}.txt`, 'utf-8')
     const isLargeOutput = data.length > 65000
     const refreshLinesRegex = /: Refreshing state\.\.\.\s*\[id=/i
-    const { steps } = context
 
     let plan = data
     if (isLargeOutput)
@@ -16,7 +15,7 @@ module.exports = ({ context, github, stackName }) => {
     const remoteRunLinkMatch = remoteRunLinkRegex.exec(plan)
     const remoteRunLink = remoteRunLinkMatch !== null ? remoteRunLinkMatch[1] : null
 
-    const output = `#### [\`${stackName}\`] Terraform Plan 📖\`${steps.plan.outcome}\`
+    const output = `#### [\`${stackName}\`] Terraform Plan 📖\`${planOutcome}\`
 
         ${remoteRunLink ? `<a href="${remoteRunLink}" target="_blank">Remote Plan Link ↗️</a>` : ""}
 

--- a/.github/lib/comment-plan-output.js
+++ b/.github/lib/comment-plan-output.js
@@ -1,5 +1,5 @@
 
-module.exports = ({ context, github, planOutcome, stackName }) => {
+module.exports = ({ context, github, planOutcome, pusher, actionName, workflowName, workingDirectory, stackName }) => {
     const { readFileSync } = require("fs")
     const data = readFileSync(`./plan_stdout_${stackName}.txt`, 'utf-8')
     const isLargeOutput = data.length > 65000
@@ -27,7 +27,7 @@ module.exports = ({ context, github, planOutcome, stackName }) => {
 
         </details>
 
-        *Pusher: @${github.actor}, Action: \`${github.event_name}\`, Working Directory: \`${context.env.tf_actions_working_dir}\`, Workflow: \`${github.workflow}\`*`;
+        *Pusher: @${pusher}, Action: \`${actionName}\`, Working Directory: \`${workingDirectory}\`, Workflow: \`${workflowName}\`*`;
 
     github.issues.createComment({
         issue_number: context.issue.number,

--- a/.github/lib/comment-plan-output.js
+++ b/.github/lib/comment-plan-output.js
@@ -17,17 +17,17 @@ module.exports = ({ context, github, planOutcome, pusher, actionName, workflowNa
 
     const output = `#### [\`${stackName}\`] Terraform Plan 📖\`${planOutcome}\`
 
-        ${remoteRunLink ? `<a href="${remoteRunLink}" target="_blank">Remote Plan Link ↗️</a>` : ""}
+${remoteRunLink ? `<a href="${remoteRunLink}" target="_blank">Remote Plan Link ↗️</a>` : ""}
 
-        <details><summary>Show Plan</summary>
+<details><summary>Show Plan</summary>
 
-        \`\`\`tf
-        ${plan}
-        \`\`\`
+\`\`\`tf
+${plan}
+\`\`\`
 
-        </details>
+</details>
 
-        *Pusher: @${pusher}, Action: \`${actionName}\`, Working Directory: \`${workingDirectory}\`, Workflow: \`${workflowName}\`*`;
+*Pusher: @${pusher}, Action: \`${actionName}\`, Working Directory: \`${workingDirectory}\`, Workflow: \`${workflowName}\`*`;
 
     github.issues.createComment({
         issue_number: context.issue.number,

--- a/.github/lib/comment-plan-output.js
+++ b/.github/lib/comment-plan-output.js
@@ -1,9 +1,10 @@
 
-module.exports = ({ steps, github, stackName }) => {
+module.exports = ({ context, github, stackName }) => {
     const { readFileSync } = require("fs")
     const data = readFileSync(`./plan_stdout_${stackName}.txt`, 'utf-8')
     const isLargeOutput = data.length > 65000
     const refreshLinesRegex = /: Refreshing state\.\.\.\s*\[id=/i
+    const { steps } = context
 
     let plan = data
     if (isLargeOutput)
@@ -27,7 +28,7 @@ module.exports = ({ steps, github, stackName }) => {
 
         </details>
 
-        *Pusher: @${github.actor}, Action: \`${github.event_name}\`, Working Directory: \`${process.env.tf_actions_working_dir}\`, Workflow: \`${github.workflow}\`*`;
+        *Pusher: @${github.actor}, Action: \`${github.event_name}\`, Working Directory: \`${context.env.tf_actions_working_dir}\`, Workflow: \`${github.workflow}\`*`;
 
     github.issues.createComment({
         issue_number: context.issue.number,

--- a/.github/lib/comment-plan-output.js
+++ b/.github/lib/comment-plan-output.js
@@ -1,0 +1,38 @@
+
+module.exports = ({ steps, github, stackName }) => {
+    const { readFileSync } = require("fs")
+    const data = readFileSync(`./plan_stdout_${stackName}.txt`, 'utf-8')
+    const isLargeOutput = data.length > 65000
+    const refreshLinesRegex = /: Refreshing state\.\.\.\s*\[id=/i
+
+    let plan = data
+    if (isLargeOutput)
+        plan = plan.split("\n").filter(line => !refreshLinesRegex.test(line)).join("\n")
+
+    plan = plan.length > 65000 ? `${plan.substring(0, 65000)}...` : plan
+
+    const remoteRunLinkRegex = /^(.*app\.terraform\.io\/app.*)$/m
+    const remoteRunLinkMatch = remoteRunLinkRegex.exec(plan)
+    const remoteRunLink = remoteRunLinkMatch !== null ? remoteRunLinkMatch[1] : null
+
+    const output = `#### [\`${stackName}\`] Terraform Plan 📖\`${steps.plan.outcome}\`
+
+        ${remoteRunLink ? `<a href="${remoteRunLink}" target="_blank">Remote Plan Link ↗️</a>` : ""}
+
+        <details><summary>Show Plan</summary>
+
+        \`\`\`tf
+        ${plan}
+        \`\`\`
+
+        </details>
+
+        *Pusher: @${github.actor}, Action: \`${github.event_name}\`, Working Directory: \`${process.env.tf_actions_working_dir}\`, Workflow: \`${github.workflow}\`*`;
+
+    github.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: output
+    })
+}

--- a/.github/lib/create-pr.js
+++ b/.github/lib/create-pr.js
@@ -1,13 +1,13 @@
-module.exports = async ({ github }) => {
+module.exports = async ({ github, runNumber, providerName }) => {
     const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env
     const url = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
-    const repo = "cdktf-provider-${{ matrix.provider }}"
+    const repo = `cdktf-provider-${providerName}`
     const owner = 'cdktf'
 
     const { data } = await github.pulls.create({
         owner,
         repo,
-        head: "upgrade-provider-project-${{ github.run_number }}",
+        head: `upgrade-provider-project-${runNumber}`,
         base: "main",
         title: "chore(deps): upgrade provider project",
         maintainer_can_modify: true,

--- a/.github/lib/create-pr.js
+++ b/.github/lib/create-pr.js
@@ -1,0 +1,26 @@
+module.exports = async ({ github }) => {
+    const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env
+    const url = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
+    const repo = "cdktf-provider-${{ matrix.provider }}"
+    const owner = 'cdktf'
+
+    const { data } = await github.pulls.create({
+        owner,
+        repo,
+        head: "upgrade-provider-project-${{ github.run_number }}",
+        base: "main",
+        title: "chore(deps): upgrade provider project",
+        maintainer_can_modify: true,
+        body: `Triggered by ${url}`
+    })
+
+    console.log(`Created a PR: ${data.html_url}`)
+
+    await github.issues.addLabels({
+        owner,
+        repo,
+        issue_number: data.number,
+        labels: ['automerge']
+    })
+
+}

--- a/.github/lib/create-projen-files.js
+++ b/.github/lib/create-projen-files.js
@@ -1,11 +1,11 @@
 
-module.exports = () => {
+module.exports = ({ providerName }) => {
     const path = require('path')
     const fs = require('fs')
     const provider = require('./main/provider.json')
-    const providerVersion = provider["${{ matrix.provider }}"]
+    const providerVersion = provider[providerName]
     const providersWithCustomRunners = require('./main/providersWithCustomRunners.json')
-    const useCustomGithubRunner = providersWithCustomRunners.includes("${{ matrix.provider }}");
+    const useCustomGithubRunner = providersWithCustomRunners.includes(providerName);
     const template = fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'main', 'projenrc.template.js'), 'utf-8')
     const projenrc = template.replace('__PROVIDER__', providerVersion).replace('__CUSTOM_RUNNER__', useCustomGithubRunner)
     fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, 'provider', '.projenrc.js'), projenrc)

--- a/.github/lib/create-projen-files.js
+++ b/.github/lib/create-projen-files.js
@@ -1,0 +1,12 @@
+
+module.exports = () => {
+    const path = require('path')
+    const fs = require('fs')
+    const provider = require('./main/provider.json')
+    const providerVersion = provider["${{ matrix.provider }}"]
+    const providersWithCustomRunners = require('./main/providersWithCustomRunners.json')
+    const useCustomGithubRunner = providersWithCustomRunners.includes("${{ matrix.provider }}");
+    const template = fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'main', 'projenrc.template.js'), 'utf-8')
+    const projenrc = template.replace('__PROVIDER__', providerVersion).replace('__CUSTOM_RUNNER__', useCustomGithubRunner)
+    fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, 'provider', '.projenrc.js'), projenrc)
+}

--- a/.github/lib/detect-breaking-changes.js
+++ b/.github/lib/detect-breaking-changes.js
@@ -1,0 +1,80 @@
+const v = (key, input) =>
+    new RegExp(`${key}:[\\D]*(\\d+(\\.\\d+)*)`).exec(input)[1];
+
+const terraformProviderName = (input) =>
+    new RegExp(`terraformProvider:\\s("|')(.*)@`).exec(input)[2];
+
+const parse = (version) => {
+    const parts = version.split(".");
+    return {
+        major: Number(parts[0]),
+        minor: Number(parts[1]),
+        patch: Number(parts[2]),
+    };
+};
+
+const isBreaking = (key) => {
+    const bef = parse(v(key, before));
+    const aft = parse(v(key, after));
+    const majorIncreased = aft.major > bef.major;
+    const isDev = aft.major === 0 && bef.major === 0;
+    const minorIncreased = aft.minor > bef.minor;
+    return majorIncreased || (isDev && minorIncreased);
+};
+
+module.exports = async ({ core, exec }) => {
+    const path = require('path')
+    const fs = require('fs')
+    const after = fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'provider', '.projenrc.js')).toString()
+
+    let before;
+    try {
+        before = (await exec.getExecOutput('git', ['show', 'HEAD:.projenrc.js'], { cwd: path.join(process.env.GITHUB_WORKSPACE, 'provider') })).stdout
+    } catch (e) {
+        if (e.message.includes("failed with exit code 128")) {
+            console.log(e);
+            before = after; // no previous version yet? use the current one as previous
+        } else {
+            throw e;
+        }
+    }
+
+    const results = [
+        "terraformProvider",
+        "cdktfVersion",
+        "constructsVersion",
+        "minNodeVersion",
+        "jsiiVersion",
+    ].map((key) => ({
+        key,
+        before: v(key, before),
+        after: v(key, after),
+        breaking: isBreaking(key),
+    }));
+
+    const providerNameChanged = ["terraformProvider"].map((key) => ({
+        key,
+        before: terraformProviderName(before),
+        after: terraformProviderName(after),
+        breaking: terraformProviderName(before) !== terraformProviderName(after),
+    }));
+
+    const hasBreakingChanges = [...results, ...providerNameChanged].some(
+        (res) => res.breaking
+    );
+
+    console.log(
+        hasBreakingChanges ? "Found breaking changes!" : "No breaking changes."
+    );
+
+    [...results, ...providerNameChanged].forEach((res) =>
+        console.log(
+            `${res.key}: ${res.before} => ${res.after} (${res.breaking ? "breaking" : "non-breaking"
+            })`
+        )
+    );
+
+    if (hasBreakingChanges) {
+        core.setOutput("has_breaking_changes", true)
+    }
+}

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -58,4 +58,4 @@ jobs:
           script: |
             const {resolve} = require('path')
             const scriptPath = resolve("./.github/lib/comment-plan-output")
-            require(scriptPath)({github, steps, stackName: ${{matrix.stack}}})
+            require(scriptPath)({github, context, planOutcome: steps.plan.outcome, stackName: matrix.stack})

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -58,4 +58,12 @@ jobs:
           script: |
             const {resolve} = require('path')
             const scriptPath = resolve("./.github/lib/comment-plan-output")
-            require(scriptPath)({github, context, planOutcome: "${{steps.plan.outcome}}", stackName: "${{matrix.stack}}" })
+            require(scriptPath)({
+              context, 
+              planOutcome: "${{steps.plan.outcome}}",
+              pusher: "${{github.actor}}",
+              actionName: "${{github.event_name}}",
+              workingDirectory: "${{env.tf_actions_working_dir}}",
+              workflowName: "${{github.workflow}}",
+              stackName: "${{matrix.stack}}" 
+            })

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -56,38 +56,4 @@ jobs:
         with:
           github-token: ${{ secrets.GH_COMMENT_TOKEN }}
           script: |
-            const { readFileSync } = require("fs")
-            const data = readFileSync('./plan_stdout_${{ matrix.stack }}.txt', 'utf-8')
-            const isLargeOutput = data.length > 65000
-            const refreshLinesRegex = /: Refreshing state\.\.\.\s*\[id=/i
-
-            let plan = data
-            if (isLargeOutput)
-                plan = plan.split("\n").filter(line => !refreshLinesRegex.test(line)).join("\n")
-
-            plan = plan.length > 65000 ? `${plan.substring(0, 65000)}...` : plan
-
-            const remoteRunLinkRegex = /^(.*app\.terraform\.io\/app.*)$/m
-            const remoteRunLinkMatch = remoteRunLinkRegex.exec(plan)
-            let remoteRunLink = remoteRunLinkMatch !== null ? remoteRunLinkMatch[1] : null
-
-            const output = `#### [\`${{matrix.stack}}\`] Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-
-            ${remoteRunLink ? `<a href="${remoteRunLink}" target="_blank">Remote Plan Link ↗️</a>` : ""}
-
-            <details><summary>Show Plan</summary>
-
-            \`\`\`tf
-            ${plan}
-            \`\`\`
-
-            </details>
-
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
-
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
+            require("./.github/lib/comment-plan-output")({github, steps, stackName: matrix.stack})

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -56,4 +56,6 @@ jobs:
         with:
           github-token: ${{ secrets.GH_COMMENT_TOKEN }}
           script: |
-            require("./.github/lib/comment-plan-output")({github, steps, stackName: matrix.stack})
+            const {resolve} = require('path')
+            const scriptPath = resolve("./.github/lib/comment-plan-output")
+            require(scriptPath)({github, steps, stackName: ${{matrix.stack}}})

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -60,6 +60,7 @@ jobs:
             const scriptPath = resolve("./.github/lib/comment-plan-output")
             require(scriptPath)({
               context, 
+              github,
               planOutcome: "${{steps.plan.outcome}}",
               pusher: "${{github.actor}}",
               actionName: "${{github.event_name}}",

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -58,4 +58,4 @@ jobs:
           script: |
             const {resolve} = require('path')
             const scriptPath = resolve("./.github/lib/comment-plan-output")
-            require(scriptPath)({github, context, planOutcome: steps.plan.outcome, stackName: matrix.stack})
+            require(scriptPath)({github, context, planOutcome: "${{steps.plan.outcome}}", stackName: "${{matrix.stack}}" })

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -70,7 +70,9 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            const script = require("./main/.github/lib/detect-breaking-changes")
+            const {resolve} = require('path')
+            const scriptPath = resolve("./main/.github/lib/detect-breaking-changes")
+            const script = require(scriptPath)
             await script({core, exec})
 
       - if: steps.git_diff.outputs.has_changes && !steps.diff_breaking.outputs.has_breaking_changes
@@ -99,6 +101,7 @@ jobs:
           script: |
             const {resolve} = require('path')
             const scriptPath = resolve("./main/.github/lib/create-pr")
+            const script = require(scriptPath)
             await script({
               github,
               runNumber: "${{github.run_number}}",

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -97,8 +97,13 @@ jobs:
         with:
           github-token: ${{ secrets.GH_COMMENT_TOKEN }}
           script: |
-            const script = require("./main/.github/lib/create-pr")
-            await script({github})
+            const {resolve} = require('path')
+            const scriptPath = resolve("./main/.github/lib/create-pr")
+            await script({
+              github,
+              runNumber: "${{github.run_number}}",
+              providerName: "${{matrix.provider}}"
+            })
 
       - name: Send failures to Slack
         if: ${{ failure() && !cancelled() }}

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -43,7 +43,13 @@ jobs:
         name: Create projen run commands file
         with:
           script: |
-            require("./main/.github/lib/create-projen-files")()
+            const {resolve} = require('path')
+            const scriptPath = resolve("./main/.github/lib/create-projen-files")
+            const script = require(scriptPath)
+            script({
+              providerName: "${{matrix.provider}}"
+            })
+
 
       - name: Upgrade provider project
         run: |

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -28,28 +28,23 @@ jobs:
       matrix: ${{fromJSON(needs.build-provider-matrix.outputs.matrix)}}
       max-parallel: 10
     steps:
-      - name: Checkout
+      - name: Checkout this repository
         uses: actions/checkout@v2
         with:
           path: main
-      - name: Checkout
+      - name: Checkout cdktf-provider-${{ matrix.provider }} Repository
         uses: actions/checkout@v2
         with:
           repository: cdktf/cdktf-provider-${{ matrix.provider }}
           token: ${{ secrets.GH_COMMENT_TOKEN }}
           path: provider
+
       - uses: actions/github-script@v4
+        name: Create projen run commands file
         with:
           script: |
-            const path = require('path')
-            const fs = require('fs')
-            const provider = require('./main/provider.json')
-            const providerVersion = provider["${{ matrix.provider }}"]
-            const providersWithCustomRunners = require('./main/providersWithCustomRunners.json')
-            const useCustomGithubRunner = providersWithCustomRunners.includes("${{ matrix.provider }}");
-            const template = fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'main', 'projenrc.template.js'), 'utf-8')
-            const projenrc = template.replace('__PROVIDER__', providerVersion).replace('__CUSTOM_RUNNER__', useCustomGithubRunner)
-            fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, 'provider', '.projenrc.js'), projenrc)
+            require("./main/.github/lib/create-projen-files")()
+
       - name: Upgrade provider project
         run: |
           unset CI
@@ -62,86 +57,21 @@ jobs:
           yarn build-provider
           npx projen
         working-directory: ./provider
+
       - name: Check for changes
         id: git_diff
         run: |
           git diff --exit-code || echo "::set-output name=has_changes::true"
         working-directory: ./provider
+
       - if: steps.git_diff.outputs.has_changes
         name: Detect breaking version changes
         id: diff_breaking
         uses: actions/github-script@v4
         with:
           script: |
-            const path = require('path')
-            const fs = require('fs')
-            const after = fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'provider', '.projenrc.js')).toString()
-            let before;
-            try {
-              before = (await exec.getExecOutput('git', ['show', 'HEAD:.projenrc.js'], { cwd: path.join(process.env.GITHUB_WORKSPACE, 'provider') })).stdout
-            } catch (e) {
-              if (e.message.includes("failed with exit code 128")) {
-                console.log(e);
-                before = after; // no previous version yet? use the current one as previous
-              } else {
-                throw e;
-              }
-            }
-            const v = (key, input) =>
-              new RegExp(`${key}:[\\D]*(\\d+(\\.\\d+)*)`).exec(input)[1];
-            const terraformProviderName = (input) =>
-              new RegExp(`terraformProvider:\\s("|')(.*)@`).exec(input)[2];
-            const parse = (version) => {
-              const parts = version.split(".");
-              return {
-                major: Number(parts[0]),
-                minor: Number(parts[1]),
-                patch: Number(parts[2]),
-              };
-            };
-            const isBreaking = (key) => {
-              const bef = parse(v(key, before));
-              const aft = parse(v(key, after));
-              const majorIncreased = aft.major > bef.major;
-              const isDev = aft.major === 0 && bef.major === 0;
-              const minorIncreased = aft.minor > bef.minor;
-              return majorIncreased || (isDev && minorIncreased);
-            };
-            const results = [
-              "terraformProvider",
-              "cdktfVersion",
-              "constructsVersion",
-              "minNodeVersion",
-              "jsiiVersion",
-            ].map((key) => ({
-              key,
-              before: v(key, before),
-              after: v(key, after),
-              breaking: isBreaking(key),
-            }));
-            const providerNameChanged = ["terraformProvider"].map((key) => ({
-              key,
-              before: terraformProviderName(before),
-              after: terraformProviderName(after),
-              breaking: terraformProviderName(before) !== terraformProviderName(after),
-            }));
-
-            const hasBreakingChanges = [...results, ...providerNameChanged].some(
-              (res) => res.breaking
-            );
-            console.log(
-              hasBreakingChanges ? "Found breaking changes!" : "No breaking changes."
-            );
-            [...results, ...providerNameChanged].forEach((res) =>
-              console.log(
-                `${res.key}: ${res.before} => ${res.after} (${
-                  res.breaking ? "breaking" : "non-breaking"
-                })`
-              )
-            );
-            if (hasBreakingChanges) {
-              console.log(`::set-output name=has_breaking_changes::true`);
-            }
+            const script = require("./main/.github/lib/detect-breaking-changes")
+            await script({core, exec})
 
       - if: steps.git_diff.outputs.has_changes && !steps.diff_breaking.outputs.has_breaking_changes
         name: Commit (non breaking) and push changes (if changed)
@@ -151,6 +81,7 @@ jobs:
           git commit -m "chore(deps): upgrade provider project"
           git push --set-upstream origin upgrade-provider-project-${{ github.run_number }}
         working-directory: ./provider
+
       - if: steps.git_diff.outputs.has_changes && steps.diff_breaking.outputs.has_breaking_changes
         name: Commit (breaking) and push changes (if changed)
         run: |
@@ -159,31 +90,16 @@ jobs:
           git commit -m "chore(deps)!: upgrade provider project"
           git push --set-upstream origin upgrade-provider-project-${{ github.run_number }}
         working-directory: ./provider
+
       - if: steps.git_diff.outputs.has_changes
+        name: "Create PR"
         uses: actions/github-script@v4
         with:
           github-token: ${{ secrets.GH_COMMENT_TOKEN }}
           script: |
-            const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env
-            const url = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
-            const repo = "cdktf-provider-${{ matrix.provider }}"
-            const owner = 'cdktf'
-            const { data } = await github.pulls.create({
-              owner,
-              repo,
-              head: "upgrade-provider-project-${{ github.run_number }}",
-              base: "main",
-              title: "chore(deps): upgrade provider project",
-              maintainer_can_modify: true,
-              body: `Triggered by ${url}`
-            })
-            console.log(`Created a PR: ${data.html_url}`)
-            await github.issues.addLabels({
-              owner,
-              repo,
-              issue_number: data.number,
-              labels: ['automerge']
-            })
+            const script = require("./main/.github/lib/create-pr")
+            await script({github})
+
       - name: Send failures to Slack
         if: ${{ failure() && !cancelled() }}
         uses: slackapi/slack-github-action@v1.21.0

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ terraform.tfstate*
 .yalc
 yalc.lock
 !projenrc.template.js
+!.github/lib/*.js


### PR DESCRIPTION
⬆️ I would like to move all the JS scripts we use within this repo to their own files. The benefits are that we get syntax highlighting for the scripts, and the github action workflow files become more concise. 

⬇️ The problem with the refactor though is that I don't have a good way of testing this. So, this might cause some breakages and I'll be observing the workflows after merge and make fix PRs as we see problems.