### PR TITLE
chore: when check has name field, use name

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -117,7 +117,7 @@ class TerraformCdkProviderStack extends TerraformStack {
           "package-python",
           "package-dotnet",
           "package-go",
-          "validate",
+          "Validate PR title",
         ],
         webhookUrl: slackWebhook.stringValue,
         provider: githubProvider,


### PR DESCRIPTION
This is the reason why so many PR checks are blocked. Apparently when a check has a 'name' field, then Github only checks that instead of the job's key in the workflow yaml.