### PR TITLE
chore: add workflow to upgrade github actions

### DIFF
--- a/.github/workflows/gh-action-upgrade.yml
+++ b/.github/workflows/gh-action-upgrade.yml
@@ -1,0 +1,27 @@
+name: GitHub Actions Version Updater
+
+on:
+  schedule:
+    # Every monday at 13:37 UTC
+    - cron: 37 13 * * 1
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.7.1
+        with:
+          token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+          committer_username: "team-tf-cdk"
+          committer_email: "github-team-tf-cdk@hashicorp.com"
+          commit_message: "chore: update github workflow actions"
+          pull_request_title: "chore: update github workflow actions"
+          pull_request_team_reviewers: "@cdktf/tf-cdk-team"
+          update_version_with: "release-commit-sha"


### PR DESCRIPTION
This is mostly a direct copy of the file used in hashicorp/terraform-cdk#2422 - I was trying to figure out how to enforce this security policy in all of our repos. The Projen-based repos are going to be tougher but since this repo isn't using Projen, I figured adding this file here is easy.