### PR TITLE
chore: autoclose older GHA updater PRs

### DIFF
--- a/.github/workflows/gh-action-upgrade.yml
+++ b/.github/workflows/gh-action-upgrade.yml
@@ -9,19 +9,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+      PR_TITLE: "chore: update github workflow actions"
 
     steps:
       - uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
 
+      - name: Find and close older versions of this same PR
+        run: |
+          prlist=$(gh search prs --repo ${{ github.repository }} --state open --match title "$PR_TITLE" --json number --jq '.[].number')
+          gh pr close -d --comment "Closing this because I'm about to open a newer PR." ${prlist}
+
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.2
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
           committer_username: "team-tf-cdk"
           committer_email: "github-team-tf-cdk@hashicorp.com"
-          commit_message: "chore: update github workflow actions"
-          pull_request_title: "chore: update github workflow actions"
+          commit_message: ${{ env.PR_TITLE }}
+          pull_request_title: ${{ env.PR_TITLE }}
           pull_request_team_reviewers: "@cdktf/tf-cdk-team"
+          pull_request_labels: "dependencies,automated"
           update_version_with: "release-commit-sha"


### PR DESCRIPTION
Copying over the fix from hashicorp/terraform-cdk#2546 now that I finally got it working because otherwise this workflow gets annoying real fast.