### PR TITLE
chore: add copyright headers automation

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,13 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2020
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    ".husky/**",
+  ]
+}

--- a/.github/ISSUE_TEMPLATE/request-provider.yml
+++ b/.github/ISSUE_TEMPLATE/request-provider.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 name: New Pre-built Provider Request
 title: "New Pre-built Provider Request: PROVIDER_NAME"

--- a/.github/lib/.eslintrc.js
+++ b/.github/lib/.eslintrc.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 module.exports = {
   root: true,
   env: {

--- a/.github/lib/collect-changes.js
+++ b/.github/lib/collect-changes.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 const fs = require("fs");
 const path = require("path");
 

--- a/.github/lib/comment-plan-output.js
+++ b/.github/lib/comment-plan-output.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 
 module.exports = ({ context, github, planOutcome, pusher, actionName, workflowName, workingDirectory, stackName }) => {
     const { readFileSync } = require("fs")

--- a/.github/lib/create-pr.js
+++ b/.github/lib/create-pr.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 module.exports = async ({ github, branchName, providerName, prTitle }) => {
   const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
   const url = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;

--- a/.github/lib/create-projen-files.js
+++ b/.github/lib/create-projen-files.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 module.exports = ({ providerName }) => {
   const path = require("path");
   const fs = require("fs");

--- a/.github/workflows/add-copyright-headers.yml
+++ b/.github/workflows/add-copyright-headers.yml
@@ -1,7 +1,12 @@
 name: "Add Copyright Headers"
 
 on:
-  pull_request: {}
+  pull_request:    
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/add-copyright-headers.yml
+++ b/.github/workflows/add-copyright-headers.yml
@@ -20,9 +20,9 @@ jobs:
           git config user.name "team-tf-cdk"
           git config user.email "github-team-tf-cdk@hashicorp.com"
       - name: Setup Copywrite tool
-        uses: hashicorp/copyright-notice-automation@main
+        uses: hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce # v1.0.0
         with:
-          token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Add headers using Copywrite tool
         run: copywrite headers
       - name: Check if there are any changes

--- a/.github/workflows/add-copyright-headers.yml
+++ b/.github/workflows/add-copyright-headers.yml
@@ -1,0 +1,36 @@
+name: "Add Copyright Headers"
+
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+jobs:
+  add-copyright-headers:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Set git identity
+        run: |-
+          git config user.name "team-tf-cdk"
+          git config user.email "github-team-tf-cdk@hashicorp.com"
+      - name: Setup Copywrite tool
+        uses: hashicorp/copyright-notice-automation@main
+        with:
+          token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+      - name: Add headers using Copywrite tool
+        run: copywrite headers
+      - name: Check if there are any changes
+        id: get_changes
+        run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
+      - name: Push changes
+        if: steps.get_changes.outputs.changed != 0
+        run: |-
+          git add .
+          git commit -s -m "chore: add required copyright headers"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 queue_rules:
   - name: default
     conditions:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 export * from "./repository";
 export * from "./secrets";

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { Construct } from "constructs";
 import {
   Repository,

--- a/lib/secrets.ts
+++ b/lib/secrets.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { Construct } from "constructs";
 import { Resource, TerraformVariable } from "cdktf";
 import {

--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { Construct } from "constructs";
 import {
   App,

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 const { CdktfProviderProject } = require("@cdktf/provider-project");
 const project = new CdktfProviderProject({
   useCustomGithubRunner: __CUSTOM_RUNNER__,


### PR DESCRIPTION
This creates a new commit on each PR à la Projen self-mutation, which has the benefit that you don't have to have the Copywrite tool installed on your own system (nicer for OSS contributors).