### PR TITLE
feat: explicitly specify devDependency on @cdktf/provider-project

### DIFF
--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -6,6 +6,7 @@ const project = new CdktfProviderProject({
   constructsVersion: "^10.0.0",
   minNodeVersion: "14.17.0",
   jsiiVersion: "^1.53.0",
+  devDeps: ["@cdktf/provider-project@^0.2.95"],
 });
 
 project.synth();


### PR DESCRIPTION
as the next version of @cdktf/provider-project will stop specifying the devDep itself and start using those that were passed to it

Related to https://github.com/cdktf/cdktf-provider-project/pull/264

This has no effect until that other PR is merged and released, as the current provider project just overrides all devDependencies.