### PR TITLE
chore: Add codeowners to all cdktf-provider-{name}-go repositories

### DIFF
--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -93,19 +93,18 @@ export class RepositorySetup extends Construct {
     });
 
     // Only for go provider repositories
-    if (repository.name.endsWith("-go")) {
-      new RepositoryFile(this, "codeowners", {
-        repository: repository.name,
-        file: ".github/CODEOWNERS",
-        content: [
-          "# These owners will be the default owners for everything in ",
-          "# the repo. Unless a later match takes precedence, ",
-          "# they will be requested for review when someone opens a ",
-          "# pull request.",
-          "*       @cdktf/tf-cdk-team",
-        ].join("\n"),
-      });
-    }
+    new RepositoryFile(this, "codeowners", {
+      repository: repository.name,
+      count: `\${regex("-go", ${repository.name}) == "-go" ? 1 : 0}` as any,
+      file: ".github/CODEOWNERS",
+      content: [
+        "# These owners will be the default owners for everything in ",
+        "# the repo. Unless a later match takes precedence, ",
+        "# they will be requested for review when someone opens a ",
+        "# pull request.",
+        "*       @cdktf/tf-cdk-team",
+      ].join("\n"),
+    });
   }
 }
 

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -7,6 +7,7 @@ import {
   RepositoryWebhook,
   GithubProvider,
   DataGithubRepository,
+  RepositoryFile,
 } from "@cdktf/provider-github";
 import { SecretFromVariable } from "./secrets";
 
@@ -90,6 +91,21 @@ export class RepositorySetup extends Construct {
       events: ["issues"],
       provider,
     });
+
+    // Only for go provider repositories
+    if (repository.name.endsWith("-go")) {
+      new RepositoryFile(this, "codeowners", {
+        repository: repository.name,
+        file: ".github/CODEOWNERS",
+        content: [
+          "# These owners will be the default owners for everything in ",
+          "# the repo. Unless a later match takes precedence, ",
+          "# they will be requested for review when someone opens a ",
+          "# pull request.",
+          "*       @cdktf/tf-cdk-team",
+        ].join("\n"),
+      });
+    }
   }
 }
 

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -34,6 +34,7 @@ export class RepositorySetup extends Construct {
       "team" | "webhookUrl" | "provider" | "protectMain" | "protectMainChecks"
     > & {
       repository: Repository | DataGithubRepository;
+      repositoryName: string;
     }
   ) {
     super(scope, name);
@@ -93,18 +94,19 @@ export class RepositorySetup extends Construct {
     });
 
     // Only for go provider repositories
-    new RepositoryFile(this, "codeowners", {
-      repository: repository.name,
-      count: `\${regex("-go", ${repository.name}) == "-go" ? 1 : 0}` as any,
-      file: ".github/CODEOWNERS",
-      content: [
-        "# These owners will be the default owners for everything in ",
-        "# the repo. Unless a later match takes precedence, ",
-        "# they will be requested for review when someone opens a ",
-        "# pull request.",
-        "*       @cdktf/tf-cdk-team",
-      ].join("\n"),
-    });
+    if (config.repositoryName.endsWith("-go")) {
+      new RepositoryFile(this, "codeowners", {
+        repository: repository.name,
+        file: ".github/CODEOWNERS",
+        content: [
+          "# These owners will be the default owners for everything in ",
+          "# the repo. Unless a later match takes precedence, ",
+          "# they will be requested for review when someone opens a ",
+          "# pull request.",
+          "*       @cdktf/tf-cdk-team",
+        ].join("\n"),
+      });
+    }
   }
 }
 
@@ -146,6 +148,7 @@ export class GithubRepository extends Construct {
 
     new RepositorySetup(this, "repository-setup", {
       ...config,
+      repositoryName: name,
       repository: this.resource,
     });
   }


### PR DESCRIPTION
This PR adds a codeowners file to all prebuilt provider go repositories that are populated by each provider's release process. 

Since the `-go` repositories are somewhat special, I'm going to try this method out as it seems the most straightforward. Since the repositories aren't projen repositories, but only hold the output of the go release, they are somewhat hard to impact directly from modifying cdktf-provider-project.

One thing I'm not sure about is whether the release process will overwrite the `.github/CODEOWNERS` file.