### PR TITLE
Fix: Failing config used to generate CODEOWNERS file in `cdktf-provider-{providerName}-go` repos

### DIFF
--- a/.github/lib/copy-codeowners-file.js
+++ b/.github/lib/copy-codeowners-file.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+module.exports = () => {
+  const path = require("path");
+  const fs = require("fs");
+  const mainFolder = path.join(process.env.GITHUB_WORKSPACE, "main");
+  const codeownersFile = fs.readFileSync(
+    path.join(mainFolder, "assets", "codeowners"),
+    "utf-8"
+  );
+
+  fs.writeFileSync(
+    path.join(
+      process.env.GITHUB_WORKSPACE,
+      "provider",
+      ".github",
+      "CODEOWNERS"
+    ),
+    codeownersFile
+  );
+};

--- a/.github/lib/create-pr.js
+++ b/.github/lib/create-pr.js
@@ -3,10 +3,16 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-module.exports = async ({ github, branchName, providerName, prTitle }) => {
+module.exports = async ({
+  github,
+  branchName,
+  providerName,
+  prTitle,
+  fullRepoName,
+}) => {
   const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
   const url = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
-  const repo = `cdktf-provider-${providerName}`;
+  const repo = fullRepoName || `cdktf-provider-${providerName}`;
   const owner = "cdktf";
 
   const { data } = await github.pulls.create({

--- a/.github/workflows/add-codeowners.yml
+++ b/.github/workflows/add-codeowners.yml
@@ -2,7 +2,6 @@ name: "Add Codeowners file to Go Repositories"
 
 on:
   workflow_dispatch: {}
-  workflow_call: {}
   push:
     branches:
       - main

--- a/.github/workflows/add-codeowners.yml
+++ b/.github/workflows/add-codeowners.yml
@@ -1,0 +1,78 @@
+name: "Add Codeowners file to Go Repositories"
+
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+
+jobs:
+  build-provider-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: set-matrix
+        run: |
+          provider=$(jq -rcM "{ provider: keys }" provider.json)
+          echo "matrix=$provider" >> $GITHUB_OUTPUT
+
+  add-codeowners-file:
+    needs: build-provider-matrix
+    name: "Add Codeowners File"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJSON(needs.build-provider-matrix.outputs.matrix)}}
+      max-parallel: 10
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2
+        with:
+          path: main
+      - name: Checkout cdktf-provider-${{ matrix.provider }}-go Repository
+        uses: actions/checkout@v2
+        with:
+          repository: cdktf/cdktf-provider-${{ matrix.provider }}-go
+          token: ${{ secrets.GH_COMMENT_TOKEN }}
+          path: provider
+
+      - uses: actions/github-script@v4
+        name: Create projen run commands file
+        with:
+          script: |
+            const {resolve} = require('path')
+            const scriptPath = resolve("./main/.github/lib/copy-codeowners-file")
+            const script = require(scriptPath)
+            script()
+
+      - name: Check for changes
+        id: git_diff
+        run: |
+          git diff --exit-code || echo "has_changes=true" >> $GITHUB_OUTPUT
+        working-directory: ./provider
+
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit codeowners file and push changes
+        run: |
+          git checkout -b add-update-codeowners-file-${{ github.run_number }}-${{ github.run_attempt }}
+          git add .
+          git commit -m "Add / Update CODEOWNERS file"
+          git push --set-upstream origin add-update-codeowners-file-${{ github.run_number }}-${{ github.run_attempt }}
+        working-directory: ./provider
+
+      - if: steps.git_diff.outputs.has_changes
+        name: "Create PR"
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GH_COMMENT_TOKEN }}
+          script: |
+            const {resolve} = require('path')
+            const scriptPath = resolve("./main/.github/lib/create-pr")
+            const script = require(scriptPath)
+            await script({
+              github,
+              branchName: "add-update-codeowners-file-${{ github.run_number }}-${{ github.run_attempt }}",
+              prTitle: "Add / Update CODEOWNERS file",
+              fullRepoName: "cdktf-provider-${{matrix.provider}}-go"
+            })

--- a/.github/workflows/add-codeowners.yml
+++ b/.github/workflows/add-codeowners.yml
@@ -39,7 +39,7 @@ jobs:
           path: provider
 
       - uses: actions/github-script@v4
-        name: Create projen run commands file
+        name: Copy codeowners file to provider repo
         with:
           script: |
             const {resolve} = require('path')

--- a/.github/workflows/add-codeowners.yml
+++ b/.github/workflows/add-codeowners.yml
@@ -3,6 +3,9 @@ name: "Add Codeowners file to Go Repositories"
 on:
   workflow_dispatch: {}
   workflow_call: {}
+  push:
+    branches:
+      - main
 
 jobs:
   build-provider-matrix:

--- a/.github/workflows/add-codeowners.yml
+++ b/.github/workflows/add-codeowners.yml
@@ -2,9 +2,6 @@ name: "Add Codeowners file to Go Repositories"
 
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - main
 
 jobs:
   build-provider-matrix:

--- a/.github/workflows/add-codeowners.yml
+++ b/.github/workflows/add-codeowners.yml
@@ -14,7 +14,9 @@ jobs:
         uses: actions/checkout@v2
       - id: set-matrix
         run: |
-          provider=$(jq -rcM "{ provider: keys }" provider.json)
+          # TODO: TESTING ONLY
+          # provider=$(jq -rcM "{ provider: keys }" provider.json)
+          provider='{"provider":["hashicups"]}'
           echo "matrix=$provider" >> $GITHUB_OUTPUT
 
   add-codeowners-file:

--- a/assets/codeowners
+++ b/assets/codeowners
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a
+# pull request.
+*       @cdktf/tf-cdk-team

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -15,6 +15,8 @@ import {
   RepositoryFile,
 } from "@cdktf/provider-github";
 import { SecretFromVariable } from "./secrets";
+import { TerraformAsset } from "cdktf";
+import path = require("path");
 
 export interface ITeam {
   id: string;
@@ -100,16 +102,18 @@ export class RepositorySetup extends Construct {
 
     // Only for go provider repositories
     if (config.repositoryName.endsWith("-go")) {
+      const asset = new TerraformAsset(this, "codeowners-asset", {
+        path: path.resolve(__dirname, "..", "assets", "codeowners"),
+      });
       new RepositoryFile(this, "codeowners", {
-        repository: repository.name,
-        file: ".github/CODEOWNERS",
-        content: [
-          "# These owners will be the default owners for everything in ",
-          "# the repo. Unless a later match takes precedence, ",
-          "# they will be requested for review when someone opens a ",
-          "# pull request.",
-          "*       @cdktf/tf-cdk-team",
-        ].join("\n"),
+        repository: repository.fullName,
+        file: "CODEOWNERS",
+        commitAuthor: "team-tf-cdk",
+        commitEmail: "github-team-tf-cdk@hashicorp.com",
+        branch: "main",
+        commitMessage: "Managed by Terraform",
+        overwriteOnCreate: false,
+        content: `\${file("${asset.path}")}`,
       });
     }
   }

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -41,7 +41,6 @@ export class RepositorySetup extends Construct {
       "team" | "webhookUrl" | "provider" | "protectMain" | "protectMainChecks"
     > & {
       repository: Repository | DataGithubRepository;
-      repositoryName: string;
     }
   ) {
     super(scope, name);
@@ -99,23 +98,6 @@ export class RepositorySetup extends Construct {
       events: ["issues"],
       provider,
     });
-
-    // Only for go provider repositories
-    if (config.repositoryName.endsWith("-go")) {
-      const asset = new TerraformAsset(this, "codeowners-asset", {
-        path: path.resolve(__dirname, "..", "assets", "codeowners"),
-      });
-      new RepositoryFile(this, "codeowners", {
-        repository: repository.fullName,
-        file: "CODEOWNERS",
-        commitAuthor: "team-tf-cdk",
-        commitEmail: "github-team-tf-cdk@hashicorp.com",
-        branch: "main",
-        commitMessage: "Managed by Terraform",
-        overwriteOnCreate: false,
-        content: `\${file("${asset.path}")}`,
-      });
-    }
   }
 }
 
@@ -157,7 +139,6 @@ export class GithubRepository extends Construct {
 
     new RepositorySetup(this, "repository-setup", {
       ...config,
-      repositoryName: name,
       repository: this.resource,
     });
   }

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -12,11 +12,8 @@ import {
   RepositoryWebhook,
   GithubProvider,
   DataGithubRepository,
-  RepositoryFile,
 } from "@cdktf/provider-github";
 import { SecretFromVariable } from "./secrets";
-import { TerraformAsset } from "cdktf";
-import path = require("path");
 
 export interface ITeam {
   id: string;


### PR DESCRIPTION
There's an issue with the github provider where it fails to validate the `main` branch somehow. The error message isn't very clear, but it seems to either be an issue with the github token (which I've validated manually, does work, so that's unlikely), or the code within the Github provider.

Thus, I'm reverting that change, and going the route of a manual github action workflow that will add CODEOWNERS files to each -go repo. This is a less than ideal approach, but at this point I don't have a better idea and it's not worth spending any more time on this.