### PR TITLE
fix: CODEOWNERS workflow should make a PR for a newly added file

### DIFF
--- a/.github/workflows/add-codeowners.yml
+++ b/.github/workflows/add-codeowners.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check for changes
         id: git_diff
         run: |
-          git diff --exit-code || echo "has_changes=true" >> $GITHUB_OUTPUT
+          if (( $(git status -s | wc -l) > 0 )); then echo "has_changes=true" >> $GITHUB_OUTPUT; fi
         working-directory: ./provider
 
       - if: steps.git_diff.outputs.has_changes


### PR DESCRIPTION
git diff doesn't tell us about untracked files, so using a hacky git status workaround