### PR TITLE
chore: fix copyright headers automation

### DIFF
--- a/.github/workflows/add-copyright-headers.yml
+++ b/.github/workflows/add-copyright-headers.yml
@@ -1,7 +1,7 @@
 name: "Add Copyright Headers"
 
 on:
-  pull_request:    
+  pull_request_target:    
     types:
       - opened
       - reopened


### PR DESCRIPTION
Use `pull_request_target` so that this can run successfully for outside contributors as well.