### PR TITLE
chore: remove unused input from copywrite

### DIFF
--- a/.github/workflows/add-copyright-headers.yml
+++ b/.github/workflows/add-copyright-headers.yml
@@ -27,9 +27,7 @@ jobs:
           git config user.name "team-tf-cdk"
           git config user.email "github-team-tf-cdk@hashicorp.com"
       - name: Setup Copywrite tool
-        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
       - name: Add headers using Copywrite tool
         run: copywrite headers
       - name: Check if there are any changes


### PR DESCRIPTION
Minor nitpick but we don't need to pass the token anymore with the newer version.