### PR TITLE
fix: turn off Issues tab for go repos

### DIFF
--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -125,7 +125,7 @@ export class GithubRepository extends Construct {
       description,
       visibility: "public",
       homepageUrl: "https://cdk.tf",
-      hasIssues: true,
+      hasIssues: !name.endsWith("-go"),
       hasWiki: false,
       autoInit: true,
       hasProjects: false,


### PR DESCRIPTION
Every now and then we get stray issues reported to the `-go` repos which tend to disappear into the ether because we don't monitor these. The easiest thing to do is just turn off the Issues tab in these repos since we don't use it ourselves anyway.