### PR TITLE
fix: set GH_REPO env var in Go license script

### DIFF
--- a/.github/workflows/add-license.yml
+++ b/.github/workflows/add-license.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           repository: cdktf/cdktf-provider-${{ matrix.provider }}-go
           token: ${{ secrets.GH_COMMENT_TOKEN }}
+          fetch-depth: 0
           path: provider
 
       - name: Setup Copywrite
@@ -48,7 +49,7 @@ jobs:
 
       - name: Delete old branches from previous runs
         run: |
-          git branch -r | egrep -o "add-update-license-file.*"  | xargs -n 1 git push --delete origin
+          git branch -r | egrep -o "add-update-license-file.*" | xargs -n 1 git push origin --delete
         working-directory: ./provider
 
       - name: Add Mozilla Public License

--- a/.github/workflows/add-license.yml
+++ b/.github/workflows/add-license.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Add Mozilla Public License
         run: copywrite license --spdx "MPL-2.0"
         working-directory: ./provider
+        env:
+          GH_REPO: cdktf/cdktf-provider-${{ matrix.provider }}-go
 
       - name: Check for changes
         id: git_diff

--- a/.github/workflows/add-license.yml
+++ b/.github/workflows/add-license.yml
@@ -46,6 +46,11 @@ jobs:
           git config user.email "github-team-tf-cdk@hashicorp.com"
         working-directory: ./provider
 
+      - name: Delete old branches from previous runs
+        run: |
+          git branch -r | egrep -o "add-update-license-file.*"  | xargs -n 1 git push --delete origin
+        working-directory: ./provider
+
       - name: Add Mozilla Public License
         run: copywrite license --spdx "MPL-2.0"
         working-directory: ./provider
@@ -78,6 +83,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_COMMENT_TOKEN }}
           retries: 5
+          retry-exempt-status-codes: 400,401,404
           script: |
             const {resolve} = require('path')
             const scriptPath = resolve("./main/.github/lib/create-pr")

--- a/.github/workflows/add-license.yml
+++ b/.github/workflows/add-license.yml
@@ -51,12 +51,17 @@ jobs:
         working-directory: ./provider
         env:
           GH_REPO: cdktf/cdktf-provider-${{ matrix.provider }}-go
+          GITHUB_TOKEN: ${{ secrets.GH_COMMENT_TOKEN }}
 
       - name: Check for changes
         id: git_diff
         run: |
           if (( $(git status -s | wc -l) > 0 )); then echo "has_changes=true" >> $GITHUB_OUTPUT; fi
         working-directory: ./provider
+
+      - if: steps.git_diff.outputs.has_changes
+        name: Sleep for 2 seconds to avoid rate limits
+        run: sleep 2s
 
       - if: steps.git_diff.outputs.has_changes
         name: Commit license file and push changes

--- a/.github/workflows/add-license.yml
+++ b/.github/workflows/add-license.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           git branch -r | egrep -o "add-update-license-file.*" | xargs -n 1 git push origin --delete
         working-directory: ./provider
+        continue-on-error: true
 
       - name: Add Mozilla Public License
         run: copywrite license --spdx "MPL-2.0"

--- a/.github/workflows/add-license.yml
+++ b/.github/workflows/add-license.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ secrets.GH_COMMENT_TOKEN }}
+          retries: 5
           script: |
             const {resolve} = require('path')
             const scriptPath = resolve("./main/.github/lib/create-pr")


### PR DESCRIPTION
I tried running this script for the first time this morning and it failed. Looking into how this works in the Copywrite tool led me to https://github.com/cli/go-gh#go-library-for-the-github-cli which got me hoping that maybe all this is missing is this `GH_REPO` env var. Might be a long shot, though.