### PR TITLE
feat: add LaunchDarkly provider

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -29,6 +29,7 @@
   "http": "http@~> 3.1",
   "ionoscloud": "ionos-cloud/ionoscloud@~> 6.2",
   "kubernetes": "kubernetes@~> 2.0",
+  "launchdarkly": "launchdarkly/launchdarkly@~> 2.13",
   "local": "hashicorp/local@~> 2.1",
   "mongodbatlas": "mongodb/mongodbatlas@~> 1.8",
   "newrelic": "newrelic/newrelic@~> 3.7",

--- a/sharded-stacks.json
+++ b/sharded-stacks.json
@@ -71,7 +71,10 @@
       "backend": {
         "workspaceName": "prebuilt-providers-partners"
       },
-      "providers": ["mongodbatlas"]
+      "providers": [
+        "launchdarkly",
+        "mongodbatlas"
+      ]
     }
   }
 }


### PR DESCRIPTION
Setting up the PR as requested by Chris -- however, let's wait to merge this until we have a chance to discuss:

When I set up #208 to create the Waypoint provider recently, it mostly went fine (once the Maven issues were resolved), but the provider got created as v0.0.0 instead of v1.0.0: https://github.com/cdktf/cdktf-provider-waypoint/releases I thought we had some code in place to force the first version to be v1, but if we do, that functionality doesn't seem to be working.