### PR TITLE
feat: add oci provider

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -35,6 +35,7 @@
   "newrelic": "newrelic/newrelic@~> 3.7",
   "nomad": "nomad@~> 1.4",
   "null": "null@~> 3.0",
+  "oci": "oracle/oci@~> 5.6",
   "opc": "opc@~> 1.4",
   "oraclepaas": "oraclepaas@~> 1.5",
   "okta": "okta/okta@~> 4.0",

--- a/sharded-stacks.json
+++ b/sharded-stacks.json
@@ -73,7 +73,8 @@
       },
       "providers": [
         "launchdarkly",
-        "mongodbatlas"
+        "mongodbatlas",
+        "oci"
       ]
     }
   }


### PR DESCRIPTION
As per recommendation by @kral2, this adds a prebuilt version of https://registry.terraform.io/providers/oracle/oci