### PR TITLE
feat: allow automerge workflow on managed repositories

### DIFF
--- a/.github/lib/collect-changes.js
+++ b/.github/lib/collect-changes.js
@@ -160,7 +160,7 @@ module.exports = async ({ core, exec }) => {
   }
 
   if (commitMessageParts.length === 0) {
-    const repo = 'cdktf/cdktf-repository-manager'; // we could make this dynamic
+    const repo = "cdktf/cdktf-repository-manager"; // we could make this dynamic
     let commitHash;
     try {
       commitHash = (

--- a/.github/lib/create-pr.js
+++ b/.github/lib/create-pr.js
@@ -32,7 +32,7 @@ module.exports = async ({
     owner,
     repo,
     issue_number: data.number,
-    labels: ["automerge"],
+    labels: ["automerge", "auto-approve"],
   });
 
   if (mergePullRequest) {

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -59,6 +59,15 @@ export class RepositorySetup extends Construct {
       })
     );
 
+    setOldId(
+      new IssueLabel(this, `no-auto-close-label`, {
+        color: "EE2222",
+        name: "no-auto-close",
+        repository: repository.name,
+        provider,
+      })
+    );
+
     new IssueLabel(this, `auto-approve-label`, {
       color: "8BF8BD",
       name: "auto-approve",

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -153,6 +153,9 @@ export class GithubRepository extends Construct {
       hasProjects: false,
       deleteBranchOnMerge: true,
       allowAutoMerge: true,
+      allowUpdateBranch: true,
+      squashMergeCommitMessage: "PR_BODY",
+      squashMergeCommitTitle: "PR_TITLE",
       topics,
       provider,
     });

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -43,7 +43,7 @@ export class RepositorySetup extends Construct {
 
     const {
       protectMain = false,
-      protectMainChecks = ["build"],
+      protectMainChecks = ["build", "license/cla"],
       provider,
       repository,
       team,
@@ -59,6 +59,13 @@ export class RepositorySetup extends Construct {
       })
     );
 
+    new IssueLabel(this, `auto-approve-label`, {
+      color: "8BF8BD",
+      name: "auto-approve",
+      repository: repository.name,
+      provider,
+    });
+
     if (protectMain) {
       setOldId(
         new BranchProtection(this, "main-protection", {
@@ -67,6 +74,14 @@ export class RepositorySetup extends Construct {
           enforceAdmins: true,
           allowsDeletions: false,
           allowsForcePushes: false,
+          requiredPullRequestReviews: [
+            {
+              requiredApprovingReviewCount: 1,
+              requireCodeOwnerReviews: false, // NOTE: In the future, Security wants to enforce this, so be warned...
+              dismissStaleReviews: false,
+            },
+          ],
+          requireConversationResolution: true,
           requiredStatusChecks: [
             {
               strict: true,
@@ -137,6 +152,7 @@ export class GithubRepository extends Construct {
       autoInit: true,
       hasProjects: false,
       deleteBranchOnMerge: true,
+      allowAutoMerge: true,
       topics,
       provider,
     });
@@ -160,7 +176,7 @@ export class GithubRepositoryFromExistingRepository extends Construct {
   constructor(
     scope: Construct,
     name: string,
-    config: Pick<RepositoryConfig, "team" | "webhookUrl" | "provider"> & {
+    config: RepositoryConfig & {
       repositoryName: string;
     }
   ) {

--- a/main.ts
+++ b/main.ts
@@ -269,6 +269,18 @@ class CustomConstructsStack extends TerraformStack {
     const secrets = new PublishingSecretSet(this, "secret-set");
 
     constructRepos.forEach(({ name: repoName, languages, topics }) => {
+      const protectMainChecks = ["build", "license/cla"].concat(
+        languages.map((language) => {
+          return `package-${
+            language === "typescript"
+              ? "js"
+              : language === "csharp"
+              ? "dotnet"
+              : language
+          }`;
+        })
+      );
+
       const repo = new GithubRepositoryFromExistingRepository(
         this,
         `cdktf-construct-${repoName}`,
@@ -277,6 +289,8 @@ class CustomConstructsStack extends TerraformStack {
           team: githubTeam,
           webhookUrl: slackWebhook.stringValue,
           provider: githubProvider,
+          protectMain: true,
+          protectMainChecks,
         }
       );
 


### PR DESCRIPTION
In preparation for possibly having to get rid of Mergify, this turns on GitHub's native automerge feature for all of the managed repos and also ensures that all the managed Constructs have the correct branch protection settings applied to them. Even if we keep Mergify and don't end up using automerge, having this turned on doesn't hurt us in any way.