### PR TITLE
chore: Add script for running `force-release` on every provider

### DIFF
--- a/scripts/force-release-providers.sh
+++ b/scripts/force-release-providers.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if [[ $# -eq 0 ]] ; then
+    echo 'Usage: scripts/force-release-providers.sh <filter> <workflow-name>'
+    echo
+    echo 'Example usage:'
+    echo '  scripts/force-release-providers.sh 0.18.0 force-release'
+    exit 0
+fi
+
+providers=$(jq -rcM "keys | .[]" provider.json)
+org="cdktf"
+filter=$1
+workflow_name=$2
+
+for provider in $providers; do
+  read -p "Creating workflow for provider $provider. Continue? [y/n] " -n 1 -r
+  echo
+
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "Finding SHA for PR for $provider"
+    repo_name="cdktf/cdktf-provider-$provider"
+
+    output=$(gh pr list --repo $repo_name --state merged --json mergeCommit --search "$filter" | jq -rcM '.[] | .mergeCommit.oid')
+
+    echo "SHA found: $output"
+
+    echo "Running workflow for $provider"
+    gh workflow run "${workflow_name}.yml" --repo $repo_name -f sha=$output -f publish_to_go=true | head -1
+    sleep 3
+    url=$(gh run list --workflow="${workflow_name}.yml" --repo $repo_name --limit 1 --json url | jq -rcM '.[] | .url')
+
+    echo "Workflow started: $url"
+    echo
+  fi
+done
+

--- a/scripts/force-release-providers.sh
+++ b/scripts/force-release-providers.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 
 if [[ $# -eq 0 ]] ; then
     echo 'Usage: scripts/force-release-providers.sh <filter>'

--- a/scripts/force-release-providers.sh
+++ b/scripts/force-release-providers.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 
 if [[ $# -eq 0 ]] ; then
-    echo 'Usage: scripts/force-release-providers.sh <filter> <workflow-name>'
+    echo 'Usage: scripts/force-release-providers.sh <filter>'
+    echo
+    echo 'This script runs the workflow "force-release" on every provider listed in provider.json'
+    echo 'Please note that the tool is quite naive and will generate a release for every provider you agree with'
+    echo 'It DOES NOT see if the previous release is there or not, so please exercise caution while using it'
+    echo
+    echo 'It does ask before forcing the release for every provider individually, so it can be used for a subset of providers'
     echo
     echo 'Example usage:'
-    echo '  scripts/force-release-providers.sh 0.18.0 force-release'
+    echo '  scripts/force-release-providers.sh 0.18.0'
     exit 0
 fi
 
 providers=$(jq -rcM "keys | .[]" provider.json)
 org="cdktf"
 filter=$1
-workflow_name=$2
+workflow_name=force-release
 
 for provider in $providers; do
   read -p "Creating workflow for provider $provider. Continue? [y/n] " -n 1 -r


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->
### Description

Recently we had a situation where we released a new version of CDKTF, and then promptly triggered all prebuilt providers to be re-generated. However, the go release failed on every prebuilt provider. Our current CI implementation on the providers doesn't allow us to manually release a version for just a specific language, so I built the [force-release workflow](https://github.com/cdktf/cdktf-provider-project/blob/main/src/force-release.ts) that's present on every provider. Even then, running that workflow manually by finding the right SHA for the PR and then triggering the release is too cumbersome at this scale. Thus, this script was created and it can be used to (_very carefully, please_) run the force-release workflow across the entire prebuild provider portfolio

