### PR TITLE
chore: update Nomad to v2

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -33,7 +33,7 @@
   "local": "hashicorp/local@~> 2.1",
   "mongodbatlas": "mongodb/mongodbatlas@~> 1.8",
   "newrelic": "newrelic/newrelic@~> 3.7",
-  "nomad": "nomad@~> 1.4",
+  "nomad": "nomad@~> 2.0",
   "null": "null@~> 3.0",
   "opc": "opc@~> 1.4",
   "oraclepaas": "oraclepaas@~> 1.5",


### PR DESCRIPTION
v2.0 of the Nomad provider went generally available last week. This updates it on our side.