### PR TITLE
feat: automate upgrading CDKTF

### DIFF
--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -20,26 +20,26 @@ jobs:
         # NOTE: This uses the version in projenrc.template.js as the source of truth (and not the version of cdktf in the repo-manager's package.json)
         run: |-
           OLD_VERSION=$(sed -nE 's/cdktfVersion: "\^(.*)",/\1/p' projenrc.template.js | xargs)
-          OLD_VERSION_SHORT=$(cut -d "." -f 2 <<< "$OLD_VERSION")
+          OLD_VERSION_MINOR=$(cut -d "." -f 2 <<< "$OLD_VERSION")
           echo "value=$OLD_VERSION" >> $GITHUB_OUTPUT
-          echo "short=$OLD_VERSION_SHORT" >> $GITHUB_OUTPUT
+          echo "short=$OLD_VERSION_MINOR" >> $GITHUB_OUTPUT
       - name: Get latest CDKTF version
         id: latest_version
         run: |-
           CDKTF_VERSION=$(yarn info cdktf --json | jq -r '.data.version')
-          CDKTF_VERSION_SHORT=$(cut -d "." -f 2 <<< "$CDKTF_VERSION")
+          CDKTF_VERSION_MINOR=$(cut -d "." -f 2 <<< "$CDKTF_VERSION")
           echo "value=$CDKTF_VERSION" >> $GITHUB_OUTPUT
-          echo "short=$CDKTF_VERSION_SHORT" >> $GITHUB_OUTPUT
+          echo "short=$CDKTF_VERSION_MINOR" >> $GITHUB_OUTPUT
     outputs:
       current_version: ${{ steps.current_version.outputs.value }}
-      current_version_short: ${{ steps.current_version.outputs.short }}
+      current_version_minor: ${{ steps.current_version.outputs.short }}
       latest_version: ${{ steps.latest_version.outputs.value }}
-      latest_version_short: ${{ steps.latest_version.outputs.short }}
+      latest_version_minor: ${{ steps.latest_version.outputs.short }}
   upgrade_repos:
     name: Upgrade CDKTF in prebuilt provider repos
     runs-on: ubuntu-latest
     needs: [check_versions]
-    if: needs.check_versions.outputs.current_version_short != needs.check_versions.outputs.latest_version_short
+    if: needs.check_versions.outputs.current_version_minor != needs.check_versions.outputs.latest_version_minor
     permissions:
       contents: read
     steps:
@@ -54,7 +54,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
         with:
-          branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_short }}
+          branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_minor }}
           base: main
           commit-message: "feat!: upgrade providers to CDKTF version ${{ needs.check_versions.outputs.latest_version }}"
           title: "feat!: upgrade providers to CDKTF version ${{ needs.check_versions.outputs.latest_version }}"
@@ -71,7 +71,7 @@ jobs:
     name: Upgrade CDKTF in repository-manager
     runs-on: ubuntu-latest
     needs: [check_versions, upgrade_repos]
-    if: needs.check_versions.outputs.current_version_short != needs.check_versions.outputs.latest_version_short
+    if: needs.check_versions.outputs.current_version_minor != needs.check_versions.outputs.latest_version_minor
     permissions:
       contents: read
     steps:
@@ -88,7 +88,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
         with:
-          branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_short }}
+          branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_minor }}
           base: main
           commit-message: "chore: upgrade self to cdktf ${{ needs.check_versions.outputs.latest_version }}"
           title: "chore: upgrade self to cdktf ${{ needs.check_versions.outputs.latest_version }}"

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -54,10 +54,10 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
         with:
-          commit-message: "feat!: upgrade providers to cdktf ${{ needs.check_versions.outputs.latest_version }}"
           branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_short }}
           base: main
-          title: "feat!: upgrade providers to cdktf ${{ needs.check_versions.outputs.latest_version }}"
+          commit-message: "feat!: upgrade providers to CDKTF version ${{ needs.check_versions.outputs.latest_version }}"
+          title: "feat!: upgrade providers to CDKTF version ${{ needs.check_versions.outputs.latest_version }}"
           body: This PR upgrades CDKTF from version `${{ needs.check_versions.outputs.current_version }}` to version `${{ needs.check_versions.outputs.latest_version }}` in the prebuilt providers managed by this project.
           labels: automated
           token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
@@ -88,9 +88,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
         with:
-          commit-message: "chore: upgrade self to cdktf ${{ needs.check_versions.outputs.latest_version }}"
           branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_short }}
           base: main
+          commit-message: "chore: upgrade self to cdktf ${{ needs.check_versions.outputs.latest_version }}"
           title: "chore: upgrade self to cdktf ${{ needs.check_versions.outputs.latest_version }}"
           body: |
             This PR upgrades CDKTF to version `${{ needs.check_versions.outputs.latest_version }}` in `cdktf-repository-manager` (this repo).

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -1,0 +1,109 @@
+name: upgrade-cdktf
+on:
+  schedule:
+    - cron: 13 */6 * * *
+  workflow_dispatch: {}
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  check_versions:
+    name: Check CDKTF versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Install
+        run: yarn install
+      - name: Get current CDKTF version
+        id: current_version
+        # NOTE: This uses the version in projenrc.template.js as the source of truth (and not the version of cdktf in the repo-manager's package.json)
+        run: |-
+          OLD_VERSION=$(sed -nE 's/cdktfVersion: "\^(.*)",/\1/p' projenrc.template.js | xargs)
+          OLD_VERSION_SHORT=$(cut -d "." -f 2 <<< "$OLD_VERSION")
+          echo "value=$OLD_VERSION" >> $GITHUB_OUTPUT
+          echo "short=$OLD_VERSION_SHORT" >> $GITHUB_OUTPUT
+      - name: Get latest CDKTF version
+        id: latest_version
+        run: |-
+          CDKTF_VERSION=$(yarn info cdktf --json | jq -r '.data.version')
+          CDKTF_VERSION_SHORT=$(cut -d "." -f 2 <<< "$CDKTF_VERSION")
+          echo "value=$CDKTF_VERSION" >> $GITHUB_OUTPUT
+          echo "short=$CDKTF_VERSION_SHORT" >> $GITHUB_OUTPUT
+    outputs:
+      current_version: ${{ steps.current_version.outputs.value }}
+      current_version_short: ${{ steps.current_version.outputs.short }}
+      latest_version: ${{ steps.latest_version.outputs.value }}
+      latest_version_short: ${{ steps.latest_version.outputs.short }}
+  upgrade_repos:
+    name: Upgrade CDKTF in prebuilt provider repos
+    runs-on: ubuntu-latest
+    needs: [check_versions]
+    if: needs.check_versions.outputs.current_version_short != needs.check_versions.outputs.latest_version_short
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Do the upgrade
+        run: |
+          sed -i "s/cdktfVersion: \".*\",/cdktfVersion: \"^$NEW_CDKTF_VERSION\",/" ./projenrc.template.js
+        env:
+          NEW_CDKTF_VERSION: ${{ needs.check_versions.outputs.latest_version }}
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
+        with:
+          commit-message: "feat!: upgrade providers to cdktf ${{ needs.check_versions.outputs.latest_version }}"
+          branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_short }}
+          base: main
+          title: "feat!: upgrade providers to cdktf ${{ needs.check_versions.outputs.latest_version }}"
+          body: This PR upgrades CDKTF from version `${{ needs.check_versions.outputs.current_version }}` to version `${{ needs.check_versions.outputs.latest_version }}` in the prebuilt providers managed by this project.
+          labels: automated
+          token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+          author: team-tf-cdk <github-team-tf-cdk@hashicorp.com>
+          committer: team-tf-cdk <github-team-tf-cdk@hashicorp.com>
+          signoff: true
+          delete-branch: true
+    outputs:
+      pr_id: ${{ steps.cpr.outputs.pull-request-number }}
+  upgrade_self:
+    name: Upgrade CDKTF in repository-manager
+    runs-on: ubuntu-latest
+    needs: [check_versions, upgrade_repos]
+    if: needs.check_versions.outputs.current_version_short != needs.check_versions.outputs.latest_version_short
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Install
+        run: yarn install
+      - name: Do the upgrade
+        run: |
+          yarn add cdktf@^$NEW_CDKTF_VERSION
+          yarn add cdktf-cli@^$NEW_CDKTF_VERSION
+        env:
+          NEW_CDKTF_VERSION: ${{ needs.check_versions.outputs.latest_version }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
+        with:
+          commit-message: "chore: upgrade self to cdktf ${{ needs.check_versions.outputs.latest_version }}"
+          branch: auto/upgrade-cdktf-${{ needs.check_versions.outputs.latest_version_short }}
+          base: main
+          title: "chore: upgrade self to cdktf ${{ needs.check_versions.outputs.latest_version }}"
+          body: |
+            This PR upgrades CDKTF to version `${{ needs.check_versions.outputs.latest_version }}` in `cdktf-repository-manager` (this repo).
+            Unfortunately, not everything can be automated, and the following steps need to be completed manually:
+
+            - [ ] Wait for #${{ needs.upgrade_repos.outputs.pr_id }} to be merged and for the deployment to succeed
+            - [ ] Upgrade `@cdktf/provider-github` to a version compatible with `cdktf@${{ needs.check_versions.outputs.latest_version }}` (`yarn add ...`)
+
+            Please checkout this PR, complete the above steps, push the changes to this branch, and then mark this PR as ready for review to complete the upgrade. Thanks!
+          labels: automerge,automated,dependencies
+          token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+          author: team-tf-cdk <github-team-tf-cdk@hashicorp.com>
+          committer: team-tf-cdk <github-team-tf-cdk@hashicorp.com>
+          signoff: true
+          delete-branch: true
+          draft: true


### PR DESCRIPTION
This workflow adapts scripts we're using elsewhere already like https://github.com/hashicorp/cdktf-aws-cdk/blob/main/.github/workflows/upgrade-cdktf.yml and https://github.com/hashicorp/terraform-cdk-action/blob/main/.github/workflows/upgrade-cdktf.yml to automatically create a PR to upgrade CDKTF when new (non-patch) versions come out. This variant creates two PRs:

- one to upgrade CDKTF on the prebuilt provider repos; for now, I've left the automerge label off so it will depend on us to manually approve the PR before it is merged (if anyone disagrees with that, let me know, but I feel like that's generally how we've done things)
- a draft PR to upgrade CDKTF on this repo, which will depend on the above PR being merged first (because the GitHub provider will need to be updated before this repo can do the upgrade)

Hopefully this will help prevent situations in the future like we had with this repo not updating its version of CDKTF for 6+ months.