### PR TITLE
chore: migrate from old addresses to new ones

### DIFF
--- a/.github/workflows/deploy-cdktf-stacks.yml
+++ b/.github/workflows/deploy-cdktf-stacks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1
         with:
-          terraform_version: 1.5.7
+          terraform_version: 1.6.2
           cli_config_credentials_token: ${{ secrets.TF_CLOUD_TOKEN }}
           terraform_wrapper: false
 

--- a/.github/workflows/diff-cdktf-stacks.yml
+++ b/.github/workflows/diff-cdktf-stacks.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1
         with:
-          terraform_version: 1.4.6
+          terraform_version: 1.6.2
           cli_config_credentials_token: ${{ secrets.TF_CLOUD_TOKEN }}
           terraform_wrapper: false
 


### PR DESCRIPTION
This moves our resources according to the new naming mechanism. We can remove the old resources once we are done applying this.

Please read the diff carefully as it mutates literally the entire state. I also updated the TFC workspaces to the latest (1.6.2) terraform version so that move blocks are supported