### PR TITLE
fix: remove oci provider

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -35,7 +35,6 @@
   "newrelic": "newrelic/newrelic@~> 3.7",
   "nomad": "nomad@~> 2.0",
   "null": "null@~> 3.0",
-  "oci": "oracle/oci@~> 5.6",
   "opc": "opc@~> 1.4",
   "oraclepaas": "oraclepaas@~> 1.5",
   "okta": "okta/okta@~> 4.0",

--- a/sharded-stacks.json
+++ b/sharded-stacks.json
@@ -73,8 +73,7 @@
       },
       "providers": [
         "launchdarkly",
-        "mongodbatlas",
-        "oci"
+        "mongodbatlas"
       ]
     }
   }


### PR DESCRIPTION
This reverts #211 -- the provider was never deployed successfully and requires aws/jsii#4299 to be fixed in order to work. Removing it from our workflows is the best thing to do in the meantime.