### PR TITLE
chore(deps): upgrade jsii, typescript & constructs in provider repos

### DIFF
--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -8,10 +8,11 @@ const project = new CdktfProviderProject({
   useCustomGithubRunner: __CUSTOM_RUNNER__,
   terraformProvider: "__PROVIDER__",
   cdktfVersion: "^0.19.0",
-  constructsVersion: "^10.0.0",
+  constructsVersion: "^10.3.0",
   minNodeVersion: "18.12.0",
-  jsiiVersion: "^5.0.1",
-  devDeps: ["@cdktf/provider-project@^0.3.0"],
+  jsiiVersion: "~5.2.0",
+  typescriptVersion: "~5.2.0", // NOTE: this should be the same major/minor version as JSII
+  devDeps: ["@cdktf/provider-project@^0.4.0"],
 });
 
 project.synth();


### PR DESCRIPTION
While our systems will treat this as a major breaking change, I think it should be relatively safe to merge because most of these versions are what is already in use in practice.

- `constructs`: [example](https://github.com/cdktf/cdktf-provider-aws/blob/main/yarn.lock#L1242-L1243) showing `10.3.0` is already what is being used
- `jsii`: [example](https://github.com/cdktf/cdktf-provider-aws/blob/main/yarn.lock#L2660-L2661) showing `5.2.33` is already what is being used

The only one that's new/different is the TypeScript version, but that's actually what prompted this change. Not only are the individual prebuilt provider repos [still using `^3.9.10`](https://github.com/cdktf/cdktf-provider-aws/blob/main/yarn.lock#L4144-L4145) (i.e. a _very_ old version), but this is inconsistent with the way JSII's releases are now intended to match up with TypeScript versions. From their [versioning strategy](https://github.com/aws/jsii-compiler/blob/main/SUPPORT.md):

> In-scope jsii release lines use the same major.minor version as the TypeScript compiler ([npm:typescript](https://npmjs.com/packages/typescript)) they are built with. This means that jsii@5.0.x is built on top of typescript@5.0.x.
> 
> Since the typescript package does not follow [Semantic Versioning](https://semver.org/), the jsii package does not eiher. The typescript compiler guarantees no breaking change is introduced within a given major.minor release line, and jsii upholds the same guarantee. As a consequence, users are advised to use ~ ranges (also referred to as minor-pinned ranges) when declaring dependencies on jsii.

In other words, to minimize compatibility issues, we should ensure all our repos are using Typescript ~5.2 with JSII ~5.2.