### PR TITLE
feat: create deprecation path & deprecate hashicups

### DIFF
--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -154,6 +154,7 @@ export class GithubRepository extends Construct {
     this.resource = new Repository(this, "repo", {
       name,
       description,
+      archiveOnDestroy: true,
       visibility: "public",
       homepageUrl: "https://cdk.tf",
       hasIssues: !name.endsWith("-go"),

--- a/provider.json
+++ b/provider.json
@@ -22,7 +22,6 @@
   "google": "google@~> 5.0",
   "googlebeta": "google-beta@~> 5.0",
   "googleworkspace": "googleworkspace@~> 0.7",
-  "hashicups": "hashicorp/hashicups@~> 0.3",
   "hcp": "hcp@~> 0.45",
   "hcs": "hcs@~> 0.5",
   "helm": "helm@~> 2.3",

--- a/providersWithCustomRunners.json
+++ b/providersWithCustomRunners.json
@@ -1,1 +1,1 @@
-["aws", "azurerm", "datadog", "google", "googlebeta", "kubernetes", "hashicups"]
+["aws", "azurerm", "datadog", "google", "googlebeta", "kubernetes"]

--- a/sharded-stacks.json
+++ b/sharded-stacks.json
@@ -23,7 +23,6 @@
         "gitlab",
         "google",
         "googlebeta",
-        "hashicups",
         "helm",
         "ionoscloud",
         "kubernetes",


### PR DESCRIPTION
I've been trying to think through the technical process for deprecating prebuilt providers, after confirming through #236 that in the current setup, if a provider is removed from the config, everything including the GitHub repos themselves will be deleted (once I resolved the token scope issues). This was desirable for the OCI provider, but for future prebuilt provider deprecations, we do not actually want to delete the repos, we want to archive them.

I was originally thinking we might have to create a new config/stack for `deprecatedProviders` with alternate logic for those, when I spotted the `archiveOnDestroy` setting on `GithubRepository`, which does exactly what the name suggests: instead of deleting a repo it archives it instead.

The downside of this solution is that everything else _besides_ the GitHub repo itself still gets deleted -- i.e. the issue labels, branch protection settings, and team/user assocations with the repo all get deleted before the repo is archived. The first two aren't that big of a deal, but that last one is a bit annoying because it means everyone will lose write access to the repo in case we ever wanted/needed to un-archive it in the future. (That being said, both myself and @team-tf-cdk will still have write access as a result of being workspace owners.) I went back and forth on whether this is an acceptable tradeoff but in the end I landed on the side of this is probably all right for the sake of having a much simpler and more elegant solution.

The other thing we'd have to bear in mind is that any disclaimer language we want to add to the README in the repo has to be added _before_ providers are removed here in the repo-manager, otherwise we'd have to unarchive them, update the README, and then archive them again. For that reason, I'm considering having my hack week project next week being creating a GitHub Actions workflow for deprecating a provider that creates two PRs, one in the provider repo to add the disclaimer language to the README, and a draft PR here that removes the provider from `provider.json` and `sharded-stacks.json` that says to merge the other PR first.

Before I go down that road, I wanted to put up this draft PR for discussion to make sure we're all on board with this method of deprecating prebuilt providers and see if there's anything else that I'm missing.