### PR TITLE
chore: Trigger update for maven credentials (and add comment)

### DIFF
--- a/lib/secrets.ts
+++ b/lib/secrets.ts
@@ -71,8 +71,8 @@ export class PublishingSecretSet extends Construct {
       "nuget-api-key",
       "twine-username",
       "twine-password",
-      "maven-username",
-      "maven-password",
+      "maven-username", // Use the user token from https://hashicorp.oss.sonatype.org/#profile;User%20Token (saved in 1Password)
+      "maven-password", // Use the user token password (same as above)
       "maven-gpg-private-key",
       "maven-gpg-private-key-passphrase",
       "maven-staging-profile-id",


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Description
Maven recently changed the credentials required for publishing:

<img width="848" alt="image" src="https://github.com/cdktf/cdktf-repository-manager/assets/573531/d71a9f57-69ca-4334-bdb1-962dd3071ee1">

As a reminder for future reference, the way publishing works is that we use publib through github actions within each prebuilt provider repository. The github action uses maven username and password through the repository secrets. The secrets there are written by `cdktf-repository-manager` (this repo) through Terraform. The secrets that are sent to the repository through Terraform are stored within an HCP Terraform variable set. 

While this PR only adds a comment to the secret, the true change happened within HCP Terraform. This PR was necessary to trigger the Terraform plan apply resulting in updating all Prebuilt provider repositories.