### PR TITLE
chore: enable Dependabot security updates

### DIFF
--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -11,6 +11,7 @@ import { DataGithubRepository } from "@cdktf/provider-github/lib/data-github-rep
 import { IssueLabel } from "@cdktf/provider-github/lib/issue-label";
 import { BranchProtection } from "@cdktf/provider-github/lib/branch-protection";
 import { TeamRepository } from "@cdktf/provider-github/lib/team-repository";
+import { RepositoryDependabotSecurityUpdates } from "@cdktf/provider-github/lib/repository-dependabot-security-updates";
 import { RepositoryWebhook } from "@cdktf/provider-github/lib/repository-webhook";
 
 export interface ITeam {
@@ -115,6 +116,11 @@ export class RepositorySetup extends Construct {
       // We don't need to notify about PRs since they are auto-created
       events: ["issues"],
       provider,
+    });
+
+    new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
+      repository: repository.name,
+      enabled: true,
     });
   }
 }

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -13,6 +13,7 @@ import { BranchProtection } from "@cdktf/provider-github/lib/branch-protection";
 import { TeamRepository } from "@cdktf/provider-github/lib/team-repository";
 import { RepositoryDependabotSecurityUpdates } from "@cdktf/provider-github/lib/repository-dependabot-security-updates";
 import { RepositoryWebhook } from "@cdktf/provider-github/lib/repository-webhook";
+import { Token } from "cdktf";
 
 export interface ITeam {
   id: string;
@@ -118,7 +119,7 @@ export class RepositorySetup extends Construct {
       provider,
     });
 
-    if (!repository.name.endsWith("-go")) {
+    if (!Token.asString(repository.name).endsWith("-go")) {
       new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
         repository: repository.name,
         enabled: true,

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -13,7 +13,6 @@ import { BranchProtection } from "@cdktf/provider-github/lib/branch-protection";
 import { TeamRepository } from "@cdktf/provider-github/lib/team-repository";
 import { RepositoryDependabotSecurityUpdates } from "@cdktf/provider-github/lib/repository-dependabot-security-updates";
 import { RepositoryWebhook } from "@cdktf/provider-github/lib/repository-webhook";
-import { Token } from "cdktf";
 
 export interface ITeam {
   id: string;
@@ -118,13 +117,6 @@ export class RepositorySetup extends Construct {
       events: ["issues"],
       provider,
     });
-
-    if (!Token.asString(repository.name).endsWith("-go")) {
-      new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
-        repository: repository.name,
-        enabled: true,
-      });
-    }
   }
 }
 
@@ -174,6 +166,13 @@ export class GithubRepository extends Construct {
       ...config,
       repository: this.resource,
     });
+
+    if (!name.endsWith("-go")) {
+      new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
+        repository: this.resource.name,
+        enabled: true,
+      });
+    }
   }
 
   addSecret(name: string) {
@@ -203,5 +202,12 @@ export class GithubRepositoryFromExistingRepository extends Construct {
       ...config,
       repository: this.resource,
     });
+
+    if (!config.repositoryName.endsWith("-go")) {
+      new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
+        repository: this.resource.name,
+        enabled: true,
+      });
+    }
   }
 }

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -118,10 +118,12 @@ export class RepositorySetup extends Construct {
       provider,
     });
 
-    new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
-      repository: repository.name,
-      enabled: true,
-    });
+    if (!name.endsWith("-go")) {
+      new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
+        repository: repository.name,
+        enabled: true,
+      });
+    }
   }
 }
 

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -118,7 +118,7 @@ export class RepositorySetup extends Construct {
       provider,
     });
 
-    if (!name.endsWith("-go")) {
+    if (!repository.name.endsWith("-go")) {
       new RepositoryDependabotSecurityUpdates(this, "dependabot-security", {
         repository: repository.name,
         enabled: true,


### PR DESCRIPTION
There have been a bunch of security alerts on our prebuilt provider repos recently due to dependencies like jsii and cross-spawn. These could be easily addressed by Dependabot since all they need to update is yarn.lock so they don't interfere with Projen. Enabling this will help to get security alerts addressed faster than trying to go through Projen.
