### PR TITLE
chore(deps): update pinned versions of GitHub Actions

### DIFF
--- a/.github/workflows/deploy-cdktf-stacks.yml
+++ b/.github/workflows/deploy-cdktf-stacks.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Send failures to Slack
         if: ${{ failure() && !cancelled() }}
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           payload: |
             {

--- a/.github/workflows/deploy-cdktf-stacks.yml
+++ b/.github/workflows/deploy-cdktf-stacks.yml
@@ -48,13 +48,13 @@ jobs:
         if: ${{ failure() && !cancelled() }}
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "provider_name": "stack deploy ${{ matrix.stack }}",
               "run_url": "https://github.com/cdktf/cdktf-repository-manager/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}
 
   upgrade:
     if: inputs.upgrade-repositories

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Send failures to Slack
         if: ${{ failure() && !cancelled() }}
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           payload: |
             {

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -113,10 +113,10 @@ jobs:
         if: ${{ failure() && !cancelled() }}
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "provider_name": "${{ matrix.provider }}",
               "run_url": "https://github.com/cdktf/cdktf-repository-manager/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
There are breaking changes in the v2 upgrade of the Slack integration -- see hashicorp/terraform-releases#149

TODO:
- [x] Address the breaking changes