### PR TITLE
feat: upgrade GitLab and Vault providers

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -17,7 +17,7 @@
   "dnsimple": "dnsimple/dnsimple@~> 1.0",
   "external": "external@~> 2.1",
   "github": "integrations/github@~> 6.0",
-  "gitlab": "gitlabhq/gitlab@~> 17.0",
+  "gitlab": "gitlabhq/gitlab@~> 18.0",
   "google": "google@~> 6.0",
   "googlebeta": "google-beta@~> 6.0",
   "hcp": "hcp@~> 0.45",
@@ -36,12 +36,12 @@
   "pagerduty": "PagerDuty/pagerduty@~> 3.0",
   "postgresql": "cyrilgdn/postgresql@~> 1.14",
   "random": "hashicorp/random@~> 3.1",
-  "snowflake": "Snowflake-Labs/snowflake@ ~> 1.0",
+  "snowflake": "snowflakedb/snowflake@ ~> 1.0",
   "spotinst": "spotinst/spotinst@~> 1.0",
   "tfe": "hashicorp/tfe@~> 0.33",
   "time": "hashicorp/time@~> 0.7",
   "tls": "hashicorp/tls@~> 4.0",
   "upcloud": "UpCloudLtd/upcloud@~> 5.0",
-  "vault": "hashicorp/vault@~> 4.0",
+  "vault": "hashicorp/vault@~> 5.0",
   "vsphere": "vsphere@~> 2.2"
 }


### PR DESCRIPTION
Also moves the Snowflake provider to the new namespace.

Closes #380
Closes hashicorp/terraform-cdk#3877