### PR TITLE
fix: Build provider and use the right version number for readme

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -64,7 +64,7 @@ jobs:
           yarn add --dev @cdktf/provider-project@latest
           npx projen
           yarn install --check-files
-          npx build-provider
+          yarn fetch
           # fix the readme as it requires src/version.json to be populated
           npx projen
         working-directory: ./provider

--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -61,8 +61,11 @@ jobs:
           git config user.name github-team-tf-cdk
           git config user.email github-team-tf-cdk@hashicorp.com
           git checkout -b foo-bar-${{ github.run_number }}
-          yarn install --check-files
           yarn add --dev @cdktf/provider-project@latest
+          npx projen
+          yarn install --check-files
+          npx build-provider
+          # fix the readme as it requires src/version.json to be populated
           npx projen
         working-directory: ./provider
         env:

--- a/projenrc.template.js
+++ b/projenrc.template.js
@@ -5,7 +5,6 @@
 
 const { CdktfProviderProject } = require("@cdktf/provider-project");
 
-const typescriptVersion = "~5.4.0";
 const project = new CdktfProviderProject({
   useCustomGithubRunner: __CUSTOM_RUNNER__,
   terraformProvider: "__PROVIDER__",


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Description

We accidentally removed the actual building of the provider at the time of release. This PR fixes that, along with setting the correct version number within the prebuilt provider readme.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
