### PR TITLE
feat: Update VSphere provider to new namespace

### DIFF
--- a/provider.json
+++ b/provider.json
@@ -43,5 +43,5 @@
   "tls": "hashicorp/tls@~> 4.0",
   "upcloud": "UpCloudLtd/upcloud@~> 5.0",
   "vault": "hashicorp/vault@~> 5.0",
-  "vsphere": "vsphere@~> 2.2"
+  "vsphere": "vmware/vsphere@~> 2.13"
 }


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Description

The latest version of the [vsphere provider](https://registry.terraform.io/providers/vmware/vsphere/latest) is now `vmware/vsphere` as opposed to `hashicorp/vsphere`. This PR now points the prebuilt provider to the new namespace

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
