### PR TITLE
chore(ci): add copyright headers after running yarn fetch

### DIFF
--- a/.github/workflows/upgrade-repositories.yml
+++ b/.github/workflows/upgrade-repositories.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         name: Create projen run commands file
         with:
@@ -70,6 +73,10 @@ jobs:
         working-directory: ./provider
         env:
           NODE_OPTIONS: "--max-old-space-size=7168"
+
+      - name: Add headers using Copywrite tool
+        run: copywrite headers
+        working-directory: ./provider
 
       - name: Check for changes
         id: git_diff


### PR DESCRIPTION
One of the consequences of bringing back `yarn fetch` in #389 is that because it nukes and recreates all of the contents of the `src/` directory, we lose the generated copyright headers, which is one of the reasons why these CI runs can generate PRs with thousands of changed files for some of the bigger providers like AWS, Google, etc.

I realized that another way to alleviate this problem is simply to regenerate the copyright headers as part of this workflow. This should result in diffs that are much, much smaller.